### PR TITLE
Add TargetNetStandard switch

### DIFF
--- a/Remora.Sdk/README.md
+++ b/Remora.Sdk/README.md
@@ -47,12 +47,16 @@ The following properties are defined by the SDK.
 ### Framework Targets
 The following properties are defined by the SDK.
 
-| Property              | Value                        | Overridable |
-|-----------------------|------------------------------|-------------|
-| LibraryFrameworks*    | netstandard2.1;net6.0;net7.0 | Yes         |
-| ExecutableFrameworks* | net7.0                       | Yes         |
-| TargetFramework       |                              | Yes         |
-| TargetFrameworks      | (varies)                     | Yes         |
+| Property              | Value         | Overridable |
+|-----------------------|---------------|-------------|
+| LibraryFrameworks*    | net6.0;net7.0 | Yes         |
+| ExecutableFrameworks* | net7.0        | Yes         |
+| TargetFramework       |               | Yes         |
+| TargetFrameworks      | (varies)      | Yes         |
+| TargetNetStandard     | true          | Yes         |
+
+If `TargetNetStandard` is `true`, `netstandard2.1;` will be prepended to
+LibraryFrameworks: `netstandard2.1;net6.0;net7.0`.
 
 Notably, the SDK defines a set of standard targets for libraries and frameworks,
 then applies this to the `TargetFrameworks` property based on the project's 

--- a/Remora.Sdk/README.md
+++ b/Remora.Sdk/README.md
@@ -55,8 +55,8 @@ The following properties are defined by the SDK.
 | TargetFrameworks      | (varies)      | Yes         |
 | TargetNetStandard     | true          | Yes         |
 
-If `TargetNetStandard` is `true`, `netstandard2.1;` will be prepended to
-LibraryFrameworks: `netstandard2.1;net6.0;net7.0`.
+If `TargetNetStandard` is `true`, `netstandard2.1` will be included as a target when building libraries.
+Set the property to `false` if this is undesirable.
 
 Notably, the SDK defines a set of standard targets for libraries and frameworks,
 then applies this to the `TargetFrameworks` property based on the project's 

--- a/Remora.Sdk/Sdk/Sdk.props
+++ b/Remora.Sdk/Sdk/Sdk.props
@@ -11,7 +11,8 @@
     <!-- Default targeting configuration -->
     <PropertyGroup>
         <ExecutableFrameworks Condition="'$(ExecutableFrameworks)' == ''">net8.0</ExecutableFrameworks>
-        <LibraryFrameworks Condition="'$(LibraryFrameworks)' == ''">netstandard2.1;net6.0;net7.0;$(ExecutableFrameworks)</LibraryFrameworks>
+        <LibraryFrameworks Condition="'$(LibraryFrameworks)' == ''">net6.0;net7.0;$(ExecutableFrameworks)</LibraryFrameworks>
+        <TargetNetStandard Condition="'$(TargetNetStandard)' == ''">true</TargetNetStandard>
     </PropertyGroup>
 
     <!-- Default common properties -->

--- a/Remora.Sdk/Sdk/Sdk.targets
+++ b/Remora.Sdk/Sdk/Sdk.targets
@@ -10,10 +10,10 @@
         <TargetFrameworks>$(LibraryFrameworks)</TargetFrameworks>
 
         <!--suppress MsbuildTargetFrameworkTagInspection -->
-        <TargetFrameworks Condition="'$(OutputType)' == 'Exe'">$(ExecutableFrameworks)</TargetFrameworks>
+        <TargetFrameworks Condition="'$(TargetNetStandard)' == true">netstandard2.1;$(LibraryFrameworks)</TargetFrameworks>
 
         <!--suppress MsbuildTargetFrameworkTagInspection -->
-        <TargetFrameworks Condition="'$(TargetNetStandard)' == true">netstandard2.1;$(TargetFrameworks)</TargetFrameworks>
+        <TargetFrameworks Condition="'$(OutputType)' == 'Exe'">$(ExecutableFrameworks)</TargetFrameworks>
     </PropertyGroup>
 
     <!-- Useful target information -->

--- a/Remora.Sdk/Sdk/Sdk.targets
+++ b/Remora.Sdk/Sdk/Sdk.targets
@@ -11,6 +11,9 @@
 
         <!--suppress MsbuildTargetFrameworkTagInspection -->
         <TargetFrameworks Condition="'$(OutputType)' == 'Exe'">$(ExecutableFrameworks)</TargetFrameworks>
+
+        <!--suppress MsbuildTargetFrameworkTagInspection -->
+        <TargetFrameworks Condition="'$(TargetNetStandard)' == true">netstandard2.1;$(TargetFrameworks)</TargetFrameworks>
     </PropertyGroup>
 
     <!-- Useful target information -->


### PR DESCRIPTION
As discussed in the Discord. Adds a new switch, `<TargetNetStandard />` which accepts a value of true or false (default true), to allow optionally targeting netstandard2.1.

Use:

```xml
<Project Sdk="Remora.Sdk/1.0.0">
    <PropertyGroup>
        <VersionPrefix>1.0.0</VersionPrefix>
        <TargetNetStandard>false</TargetNetStandard>
    </PropertyGroup>

    <PropertyGroup>
        <LegalAuthor>John Doe</LegalAuthor>
        <LegalEmail>john@doe.org</LegalEmail>
    </PropertyGroup>
</Project>
```

This should also be settable in the solution's `Directory.Build.props` if one desires to configure this at that level.