### PR TITLE
Remora.Tests.Sdk should not target NetStandard.

### DIFF
--- a/Remora.Tests.Sdk/Sdk/Sdk.props
+++ b/Remora.Tests.Sdk/Sdk/Sdk.props
@@ -8,6 +8,7 @@
     <!-- Override target frameworks -->
     <PropertyGroup>
         <LibraryFrameworks>$(ExecutableFrameworks)</LibraryFrameworks>
+        <TargetNetStandard>false</TargetNetStandard>
     </PropertyGroup>
 
     <!-- Default code coverage properties -->


### PR DESCRIPTION
Fixes #14 