### PR TITLE
Add Remora.Sdk.Web and Remora.Sdk.Razor

### DIFF
--- a/Remora.Sdk.Razor/README.md
+++ b/Remora.Sdk.Razor/README.md
@@ -1,0 +1,27 @@
+# Remora.Sdk.Razor
+
+This SDK provides an extension to Remora.Sdk wherein the underlying extended framework is `Microsoft.NET.Sdk.Razor`.
+
+All general `Remora.Sdk` properties and requirements apply. For instance, `LegalAuthor` and `LegalEmail` still need to
+be defined.
+
+For more information, refer to the [Remora.Sdk Readme](../Remora.Sdk/Readme.md).
+
+## Usage
+
+```xml
+<Project Sdk="Remora.Sdk.Web/1.0.0">
+	<PropertyGroup>
+		<LegalAuthor>John Doe</LegalAuthor>
+		<LegalEmail>john@doe.org</LegalEmail>
+	</PropertyGroup>
+</Project>
+```
+
+## Remora.Sdk.Web Properties
+
+No additional properties have been added at this time.
+
+## Microsoft.NET.Sdk.Razor Properties
+
+All properties added with the inclusion of `Microsoft.NET.Sdk.Razor` are available for use in projects with this type.

--- a/Remora.Sdk.Razor/Remora.Sdk.Razor.msbuildproj
+++ b/Remora.Sdk.Razor/Remora.Sdk.Razor.msbuildproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.Build.NoTargets/3.5.6">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <NoWarn>NU5128</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Title>Remora.Web.Razor</Title>
+    <Description>Provides default properties and targets for remora-style Razor projects</Description>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <PackageReleaseNotes>Initial Release</PackageReleaseNotes>
+    <IsPackable>true</IsPackable>
+    <PackageTags>MSBuild;MSBuildSdk;Remora;Web;ASP.NET Core;Razor</PackageTags>
+    <PackageType>MSBuildSdk</PackageType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="Sdk\" />
+  </ItemGroup>
+</Project>

--- a/Remora.Sdk.Razor/Sdk/Sdk.Packages.props
+++ b/Remora.Sdk.Razor/Sdk/Sdk.Packages.props
@@ -1,0 +1,10 @@
+<Project>
+	
+	<!-- 
+		Centrally managed versions for the default SDK packages - remember to update the direct references in
+		Sdk.targets, too
+	-->
+	<ItemGroup>
+	</ItemGroup>
+	
+</Project>

--- a/Remora.Sdk.Razor/Sdk/Sdk.props
+++ b/Remora.Sdk.Razor/Sdk/Sdk.props
@@ -1,0 +1,25 @@
+<Project>
+	<!-- Defaults for centrally managed package versions -->
+	<Import Project="Sdk.Packages.props"/>
+
+	<!-- Override Remora.Sdk to skip importing Microsoft.NET.Sdk-->
+	<PropertyGroup>
+		<UsingMicrosoftNETSdk>true</UsingMicrosoftNETSdk>
+		<RemoraSdkImportsMicrosoftSdk>false</RemoraSdkImportsMicrosoftSdk>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(UsingMicrosoftNETSdkWeb)' != 'true'">
+		<RemoraSdkRazorImportsMicrosoftSdkRazor>true</RemoraSdkRazorImportsMicrosoftSdkRazor>
+	</PropertyGroup>
+
+	<Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk.Razor" Condition="'$(RemoraSdkRazorImportsMicrosoftSdkRazor)' == 'true'"/>
+
+	<Import Project="Sdk.props" Sdk="Remora.Sdk" Version="3.1.2" Condition="'$(_RemoraInSourceBuild)' != 'true'"/>
+	<Import Project="../../Remora.Sdk/Sdk/Sdk.props" Condition="'$(_RemoraInSourceBuild)' == 'true'"/>
+
+	<!-- Override target frameworks -->
+	<PropertyGroup>
+		<TargetNetStandard>false</TargetNetStandard>
+	</PropertyGroup>
+
+</Project>

--- a/Remora.Sdk.Razor/Sdk/Sdk.targets
+++ b/Remora.Sdk.Razor/Sdk/Sdk.targets
@@ -1,0 +1,35 @@
+<Project>
+	<!-- Override packability -->
+	<PropertyGroup Condition="'$(OutputType)' == 'Exe'">
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<TargetFrameworkVersion>$([MSBuild]::GetTargetFrameworkIdentifier($TargetFramework))</TargetFrameworkVersion>
+	<PropertyGroup>
+		<IsNET>$(TargetFrameworkVersion) == '.NETCoreApp'</IsNET>
+		<IsNETCore>$(TargetFrameworkVersion) == '.NETCoreApp'</IsNETCore>
+		<IsNETStandard>$(TargetFrameworkVersion) == '.NETStandard'</IsNETStandard>
+		<IsNETFramework>$(TargetFrameworkVersion) == '.NETFramework'</IsNETFramework>
+		<IsRunnableTarget>$(TargetFrameworkVersion) != '.NETStandard'</IsRunnableTarget>
+	</PropertyGroup>
+	
+	<!-- Default Packages-->
+	<Choose>
+		<When Condition="'$(ManagePackageVersionsCentrally)' == true">
+			<ItemGroup>
+				<!-- TODO: Include any default package references. -->
+			</ItemGroup>
+		</When>
+		<Otherwise>
+			<ItemGroup>
+				<!-- TODO: Include any default package references.-->
+			</ItemGroup>
+		</Otherwise>
+	</Choose>
+	
+	<!-- Import last to respect set properties. -->
+	<Import Project="Sdk.targets" Sdk="Remora.Sdk" Version="3.1.2" Condition="'$(_RemoraInSourceBuild)' != 'true'"/>
+	<Import Project="../../Remora.Sdk/Sdk/Sdk.targets" Condition="'$(_RemoraInSourceBuild)' == 'true'"/>
+
+	<Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk.Razor" Condition="'$(RemoraSdkRazorImportsMicrosoftSdkRazor)' == 'true'"/>
+</Project>

--- a/Remora.Sdk.Web/README.md
+++ b/Remora.Sdk.Web/README.md
@@ -1,0 +1,27 @@
+# Remora.Sdk.Web
+
+This SDK provides an extension to Remora.Sdk wherein the underlying extended framework is `Microsoft.NET.Sdk.Web`.
+
+All general `Remora.Sdk` properties and requirements apply. For instance, `LegalAuthor` and `LegalEmail` still need to
+be defined.
+
+For more information, refer to the [Remora.Sdk Readme](../Remora.Sdk/Readme.md).
+
+## Usage
+
+```xml
+<Project Sdk="Remora.Sdk.Web/1.0.0">
+	<PropertyGroup>
+		<LegalAuthor>John Doe</LegalAuthor>
+		<LegalEmail>john@doe.org</LegalEmail>
+	</PropertyGroup>
+</Project>
+```
+
+## Remora.Sdk.Web Properties
+
+No additional properties have been added at this time.
+
+## Microsoft.NET.Sdk.Web Properties
+
+All properties added with the inclusion of `Microsoft.NET.Sdk.Web` are available for use in projects with this type.

--- a/Remora.Sdk.Web/Remora.Sdk.Web.msbuildproj
+++ b/Remora.Sdk.Web/Remora.Sdk.Web.msbuildproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.Build.NoTargets/3.5.6">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <NoWarn>NU5128</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Title>Remora.Web.Sdk</Title>
+    <Description>Provides default properties and targets for remora-style web projects</Description>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <PackageReleaseNotes>Initial Release</PackageReleaseNotes>
+    <IsPackable>true</IsPackable>
+    <PackageTags>MSBuild;MSBuildSdk;Remora;Web;ASP.NET Core;</PackageTags>
+    <PackageType>MSBuildSdk</PackageType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="Sdk\" />
+  </ItemGroup>
+</Project>

--- a/Remora.Sdk.Web/Sdk/Sdk.Packages.props
+++ b/Remora.Sdk.Web/Sdk/Sdk.Packages.props
@@ -1,0 +1,10 @@
+<Project>
+	
+	<!-- 
+		Centrally managed versions for the default SDK packages - remember to update the direct references in
+		Sdk.targets, too
+	-->
+	<ItemGroup>
+	</ItemGroup>
+	
+</Project>

--- a/Remora.Sdk.Web/Sdk/Sdk.props
+++ b/Remora.Sdk.Web/Sdk/Sdk.props
@@ -1,0 +1,25 @@
+<Project>
+	<!-- Defaults for centrally managed package versions -->
+	<Import Project="Sdk.Packages.props"/>
+
+	<!-- Override Remora.Sdk to skip importing Microsoft.NET.Sdk-->
+	<PropertyGroup>
+		<UsingMicrosoftNETSdk>true</UsingMicrosoftNETSdk>
+		<RemoraSdkImportsMicrosoftSdk>false</RemoraSdkImportsMicrosoftSdk>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(UsingMicrosoftNETSdkWeb)' != 'true'">
+		<RemoraSdkWebImportsMicrosoftSdkWeb>true</RemoraSdkWebImportsMicrosoftSdkWeb>
+	</PropertyGroup>
+
+	<Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk.Web" Condition="'$(RemoraSdkWebImportsMicrosoftSdkWeb)' == 'true'"/>
+
+	<Import Project="Sdk.props" Sdk="Remora.Sdk" Version="3.1.2" Condition="'$(_RemoraInSourceBuild)' != 'true'"/>
+	<Import Project="../../Remora.Sdk/Sdk/Sdk.props" Condition="'$(_RemoraInSourceBuild)' == 'true'"/>
+
+	<!-- Override target frameworks -->
+	<PropertyGroup>
+		<TargetNetStandard>false</TargetNetStandard>
+	</PropertyGroup>
+
+</Project>

--- a/Remora.Sdk.Web/Sdk/Sdk.targets
+++ b/Remora.Sdk.Web/Sdk/Sdk.targets
@@ -1,0 +1,35 @@
+<Project>
+	<!-- Override packability -->
+	<PropertyGroup Condition="'$(OutputType)' == 'Exe'">
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<TargetFrameworkVersion>$([MSBuild]::GetTargetFrameworkIdentifier($TargetFramework))</TargetFrameworkVersion>
+	<PropertyGroup>
+		<IsNET>$(TargetFrameworkVersion) == '.NETCoreApp'</IsNET>
+		<IsNETCore>$(TargetFrameworkVersion) == '.NETCoreApp'</IsNETCore>
+		<IsNETStandard>$(TargetFrameworkVersion) == '.NETStandard'</IsNETStandard>
+		<IsNETFramework>$(TargetFrameworkVersion) == '.NETFramework'</IsNETFramework>
+		<IsRunnableTarget>$(TargetFrameworkVersion) != '.NETStandard'</IsRunnableTarget>
+	</PropertyGroup>
+	
+	<!-- Default Packages-->
+	<Choose>
+		<When Condition="'$(ManagePackageVersionsCentrally)' == true">
+			<ItemGroup>
+				<!-- TODO: Include any default package references. -->
+			</ItemGroup>
+		</When>
+		<Otherwise>
+			<ItemGroup>
+				<!-- TODO: Include any default package references.-->
+			</ItemGroup>
+		</Otherwise>
+	</Choose>
+	
+	<!-- Import last to respect set properties. -->
+	<Import Project="Sdk.targets" Sdk="Remora.Sdk" Version="3.1.2" Condition="'$(_RemoraInSourceBuild)' != 'true'"/>
+	<Import Project="../../Remora.Sdk/Sdk/Sdk.targets" Condition="'$(_RemoraInSourceBuild)' == 'true'"/>
+
+	<Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk.Web" Condition="'$(RemoraSdkWebImportsMicrosoftSdkWeb)' == 'true'"/>
+</Project>


### PR DESCRIPTION
Adds two new SDKs: Remora.Sdk.Web (backed by Microsoft.NET.Sdk.Web) and Remora.Sdk.Razor (backed by Microsoft.NET.Sdk.Razor).

Both are pretty much identical, except for which Microsoft SDK they import.

TODO:
- [ ] Testing: Neither of these libraries have been tested with a web project at this time.